### PR TITLE
Updating isinstance() function in class _stem for compatibility with …

### DIFF
--- a/Stemmer.py
+++ b/Stemmer.py
@@ -335,7 +335,7 @@ class Stemmer:
     def _stem(cls, word):
         was_unicode = False
 
-        if isinstance(word, unicode):
+        if isinstance(word, bytes):
             was_unicode = True
             try:
                 word = word.encode('ascii')


### PR DESCRIPTION
The method _stem takes a word and checks if the encoding is in unicode. This was the syntax in older python versions. As I tried running this on my Python 3 project, it showed ''''NameError: name 'unicode' is not defined''' because unicode is deprecated.

- In Python 2, str contains sequences of 8-bit values, unicode contains sequences of Unicode characters.
- In Python 3, bytes contains sequences of 8-bit values, str contains sequences of Unicode characters. 

NOTE: This will work perfectly for Python 3.